### PR TITLE
Add retry for missing More button

### DIFF
--- a/src/main/java/bc/bfi/youtuber_about/ChromeDownloader.java
+++ b/src/main/java/bc/bfi/youtuber_about/ChromeDownloader.java
@@ -48,17 +48,21 @@ public class ChromeDownloader {
     }
 
     void openAboutDialog(WebDriver driver) {
-        int attempts = 0;
-        while (true) {
-            try {
-                driver.findElement(By.className("truncated-text-wiz__absolute-button")).click();
-                return;
-            } catch (org.openqa.selenium.NoSuchElementException ex) {
-                if (++attempts >= 3) {
-                    throw ex;
-                }
+        By selector = By.className("truncated-text-wiz__absolute-button");
+
+        for (int attempt = 0; attempt < 3; attempt++) {
+            if (attempt > 0) {
                 driver.navigate().refresh();
                 waitPageFullLoading(driver);
+            }
+
+            try {
+                driver.findElement(selector).click();
+                return;
+            } catch (org.openqa.selenium.NoSuchElementException ex) {
+                if (attempt == 2) {
+                    throw ex;
+                }
             }
         }
     }

--- a/src/test/java/bc/bfi/youtuber_about/ChromeDownloaderTest.java
+++ b/src/test/java/bc/bfi/youtuber_about/ChromeDownloaderTest.java
@@ -1,13 +1,17 @@
 package bc.bfi.youtuber_about;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Ignore;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 
 public class ChromeDownloaderTest {
 
@@ -24,5 +28,31 @@ public class ChromeDownloaderTest {
         WebDriver driver = downloader.createDriver("localhost");
 
         assertThat(driver, sameInstance(remote));
+    }
+
+    @Test
+    public void openAboutDialogShouldRetryWhenElementMissing() {
+        ChromeDownloader downloader = new ChromeDownloader() {
+            @Override
+            protected void waitPageFullLoading(WebDriver driver) {
+            }
+        };
+        assertThat(downloader, notNullValue());
+
+        WebDriver driver = mock(WebDriver.class);
+        WebDriver.Navigation navigation = mock(WebDriver.Navigation.class);
+        WebElement button = mock(WebElement.class);
+        By selector = By.className("truncated-text-wiz__absolute-button");
+
+        when(driver.findElement(selector))
+                .thenThrow(new NoSuchElementException("missing"))
+                .thenReturn(button);
+        when(driver.navigate()).thenReturn(navigation);
+
+        downloader.openAboutDialog(driver);
+
+        verify(driver, times(2)).findElement(selector);
+        verify(navigation).refresh();
+        verify(button).click();
     }
 }

--- a/src/test/java/bc/bfi/youtuber_about/ChromeDownloaderTest.java
+++ b/src/test/java/bc/bfi/youtuber_about/ChromeDownloaderTest.java
@@ -32,11 +32,7 @@ public class ChromeDownloaderTest {
 
     @Test
     public void openAboutDialogShouldRetryWhenElementMissing() {
-        ChromeDownloader downloader = new ChromeDownloader() {
-            @Override
-            protected void waitPageFullLoading(WebDriver driver) {
-            }
-        };
+        ChromeDownloader downloader = spy(new ChromeDownloader());
         assertThat(downloader, notNullValue());
 
         WebDriver driver = mock(WebDriver.class);
@@ -48,11 +44,13 @@ public class ChromeDownloaderTest {
                 .thenThrow(new NoSuchElementException("missing"))
                 .thenReturn(button);
         when(driver.navigate()).thenReturn(navigation);
+        doNothing().when(downloader).waitPageFullLoading(driver);
 
         downloader.openAboutDialog(driver);
 
         verify(driver, times(2)).findElement(selector);
         verify(navigation).refresh();
         verify(button).click();
+        verify(downloader).waitPageFullLoading(driver);
     }
 }


### PR DESCRIPTION
## Summary
- prevent hangs by adding retry with page refresh when the "more..." button is missing
- ensure the WebDriver is always closed and expose wait helpers for testing
- cover retry logic with a new unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.glassfish.jersey:jersey-bom:pom:2.27, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a44cb7c10c832b847e3ea775a46f05