### PR TITLE
Remove social links from otherLinks list

### DIFF
--- a/src/test/java/bc/bfi/youtuber_about/ParserTest.java
+++ b/src/test/java/bc/bfi/youtuber_about/ParserTest.java
@@ -16,12 +16,33 @@ public class ParserTest {
 
     @Test
     public void parseDecodesRedirectLinks() {
-        String html = "<div id='links-section'><a class='yt-core-attributed-string__link' href='https://www.youtube.com/redirect?event=channel_description&redir_token=token&q=https%3A%2F%2Ftwitter.com%2FStephenJohnPeel'></a></div>";
+        String html = "<div id='links-section'"
+                + "><a class='yt-core-attributed-string__link' href='https://www.youtube.com/redirect?event=channel_description&redir_token=token&q=https%3A%2F%2Ftwitter.com%2FStephenJohnPeel'></a>"
+                + "<a class='yt-core-attributed-string__link' href='https://www.youtube.com/redirect?event=channel_description&redir_token=token&q=https%3A%2F%2Fexample.com'></a>"
+                + "</div>";
         Parser parser = new Parser();
         ChannelAbout channel = parser.parse("https://www.youtube.com/@some/about", html);
-        String expected = "https://twitter.com/StephenJohnPeel";
-        assertThat(channel.getOtherLinks(), is(expected));
-        assertThat(channel.getLinkToTwitter(), is(expected));
+        String expectedTwitter = "https://twitter.com/StephenJohnPeel";
+        String expectedOther = "https://example.com";
+        assertThat(channel.getLinkToTwitter(), is(expectedTwitter));
+        assertThat(channel.getOtherLinks(), is(expectedOther));
+    }
+
+    @Test
+    public void parseRemovesExtractedSocialLinksFromOtherLinks() {
+        String html = "<div id='links-section'>"
+                + "<a class='yt-core-attributed-string__link' href='https://facebook.com/f'></a>"
+                + "<a class='yt-core-attributed-string__link' href='https://instagram.com/i'></a>"
+                + "<a class='yt-core-attributed-string__link' href='https://tiktok.com/@t'></a>"
+                + "<a class='yt-core-attributed-string__link' href='https://twitter.com/x'></a>"
+                + "<a class='yt-core-attributed-string__link' href='https://example.com'></a>"
+                + "</div>";
+        Parser parser = new Parser();
+        ChannelAbout channel = parser.parse("https://www.youtube.com/@some/about", html);
+        assertThat(channel.getLinkToFacebook(), is("https://facebook.com/f"));
+        assertThat(channel.getLinkToInstagram(), is("https://instagram.com/i"));
+        assertThat(channel.getLinkToTiktok(), is("https://tiktok.com/@t"));
+        assertThat(channel.getLinkToTwitter(), is("https://twitter.com/x"));
+        assertThat(channel.getOtherLinks(), is("https://example.com"));
     }
 }
-


### PR DESCRIPTION
## Summary
- Strip Facebook, Instagram, TikTok and Twitter URLs from link list during extraction
- Ensure ParserTest covers social link removal and redirect decoding

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: The following artifacts could not be resolved: org.glassfish.jersey:jersey-bom:pom:2.27 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a7aca0d7b8832b8224a85fd0db0ba0