### PR TITLE
Prevent ChannelAbout.parseNumbers from returning negatives

### DIFF
--- a/src/main/java/bc/bfi/youtuber_about/ChannelAbout.java
+++ b/src/main/java/bc/bfi/youtuber_about/ChannelAbout.java
@@ -135,7 +135,8 @@ public class ChannelAbout {
 
         try {
             double value = Double.parseDouble(input);
-            return (int) Math.round(value * multiplier);
+            int result = (int) Math.round(value * multiplier);
+            return Math.max(0, result);
         } catch (NumberFormatException e) {
             return 0; // Fallback for unexpected input
         }

--- a/src/test/java/bc/bfi/youtuber_about/ChannelAboutTest.java
+++ b/src/test/java/bc/bfi/youtuber_about/ChannelAboutTest.java
@@ -1,0 +1,17 @@
+package bc.bfi.youtuber_about;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+public class ChannelAboutTest {
+
+    @Test
+    public void getViewsAsNumberReturnsZeroWhenNegative() {
+        ChannelAbout channel = new ChannelAbout("https://example.com");
+        channel.setViews("-42 views");
+        assertThat(channel.getViewsAsNumber(), is("0"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Ensure `parseNumbers` clamps parsed values to zero so negative counts are never returned
- Add unit test covering negative input handling

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a7ae0c3cf8832b89a5564b1263cb84